### PR TITLE
Set Dependabot cooldown (default-days=3) for supported ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
       prefix: 'fix'
       prefix-development: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## Why this change?

In recent supply-chain incidents, compromised packages were typically discovered and flagged within hours. Our current setup allows Dependabot to pick up and execute fresh releases in CI almost immediately after publication, which occasionally exposes us to malicious packages before the ecosystem has reacted.

Adding a **cooldown** window makes Dependabot wait briefly before proposing updates. This gives the community (and our own security tooling) time to detect and remove compromised versions before they ever land in our CI.

We're standardizing on a **3-day cooldown** across all supported ecosystems. To be clear: This setting won't change how often you get new dependabot PRs. If you have set them to be created e.g. `monthly` you will continue to get monthly dependabot PRs. The only change is that new versions that are less than 3 days old at that point will be ignored.

## Ecosystem support

Cooldown is only applied where Dependabot supports it. If I left entries untouched, lack of support is the reason. You can see a table of supported package managers [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#configuration-of-cooldown).

## Maintenance & ownership

I don't have capacity to shepherd all these PRs into production. **Please review and merge this PR yourselves** once CI is green. Should you prefer any changes (for example an even higher cool-down period) please do them yourself as I'm creating these PRs in a semi-automated fashion.
