### PR TITLE
CLOUD-410 ktlo: pin GitHub actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,11 @@ updates:
         patterns:
           - 'vitest'
           - '@vitest/*'
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "13:00"
+      timezone: "Europe/Berlin"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -30,4 +30,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run semantic-release
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0


### PR DESCRIPTION
> **Action required from the owning team:** please review and merge this PR. It was opened as part of an org-wide rollout for [CLOUD-410](https://jimplan.atlassian.net/browse/CLOUD-410); the Cloud team is not merging on your behalf.
>
> This is a cross-repo PR from a fork in my personal account (`desouradeep/…`) because I lack direct push access to this repo. The branch and commits are on the fork; the diff is the same as the 200+ other CLOUD-410 PRs across the org.

## Summary

Pins all external GitHub Actions in this repo from mutable tags (e.g. `@v4`) to immutable commit SHAs, and ensures dependabot is configured to keep them updated.

Improves supply-chain security per [CLOUD-410](https://jimplan.atlassian.net/browse/CLOUD-410). Each pinned line keeps the original tag as a trailing comment for readability.

- Jimdo-owned actions (`Jimdo/…`) are intentionally **not** pinned (out of scope per the ticket).
- Local actions (`./...`) are untouched.
- Dependabot is configured (or updated) to track `github-actions` **monthly**, on the 1st of each month, at an hour staggered between 09:00–15:00 Europe/Berlin (one fixed hour per repo). A 3-day cooldown filters out brand-new releases.

## Test plan

- [ ] CI passes
- [ ] No unintended changes outside `.github/`


[CLOUD-410]: https://jimplan.atlassian.net/browse/CLOUD-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUD-410]: https://jimplan.atlassian.net/browse/CLOUD-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ