### PR TITLE
chore: resolve Dependabot security alert (brace-expansion) - 2026-07-26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1388,10 +1388,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1435,14 +1439,16 @@
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1672,12 +1678,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/conventional-commit-types": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
   "lint-staged": {
     "*.ts": "biome check --write"
   },
+  "overrides": {
+    "brace-expansion": "5.0.8"
+  },
   "volta": {
     "node": "24.14.0"
   },


### PR DESCRIPTION
## Summary

Resolves the Dependabot ReDoS advisory for **brace-expansion** ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)) — patched in `>=5.0.8`.

brace-expansion appears once, transitively, in the dev-tooling chain:
`@ryansonshine/commitizen > glob@7.2.3 > minimatch@3.1.5 > brace-expansion`.
`minimatch@3.1.5` pins `brace-expansion: ^1.1.7`, so `npm update` cannot reach the patched line. Since 5.0.8 is the only non-vulnerable version per the audit DB, a targeted `overrides` entry forces the single node to `5.0.8`.

## Audit delta

- Before: `brace-expansion@1.1.16` — 1 high severity (ReDoS / unbounded expansion DoS)
- After: `brace-expansion@5.0.8 (overridden)` — **0 vulnerabilities**

## Change

`package.json`: added
```json
"overrides": {
  "brace-expansion": "5.0.8"
}
```

Lockfile delta is fully scoped to the brace-expansion subtree:
- `brace-expansion` 1.1.16 → 5.0.8
- `balanced-match` (its dep) 1.0.2 → 4.0.4
- `concat-map` removed (no longer required by v5)

Engines (node `20 || >=22`) satisfied by the repo's node 24 requirement.

## Verification

- `npm ci` — passes
- `npm audit` — 0 vulnerabilities
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — 14 tests pass

Resolves Dependabot alert 53 (UXP-3360).